### PR TITLE
[FEAT] 키보드 세팅

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,23 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AndroidwantedCustomKeyboardApp"
         tools:targetApi="31">
+
+        <service
+            android:name=".KeyboardService"
+            android:enabled="true"
+            android:exported="true"
+            android:label="WantedCustomKeyboard"
+            android:permission="android.permission.BIND_INPUT_METHOD">
+
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/custom_keyboard" />
+
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+        </service>
+
         <activity
             android:name=".MainActivity"
             android:exported="true">
@@ -26,5 +43,6 @@
                 android:value="" />
         </activity>
     </application>
+
 
 </manifest>

--- a/app/src/main/java/com/preonboarding/customkeyboard/KeyboardActionListener.kt
+++ b/app/src/main/java/com/preonboarding/customkeyboard/KeyboardActionListener.kt
@@ -1,0 +1,5 @@
+package com.preonboarding.customkeyboard
+
+interface KeyboardActionListener {
+    fun changeMode(mode: Mode)
+}

--- a/app/src/main/java/com/preonboarding/customkeyboard/KeyboardService.kt
+++ b/app/src/main/java/com/preonboarding/customkeyboard/KeyboardService.kt
@@ -1,0 +1,50 @@
+package com.preonboarding.customkeyboard
+
+import android.inputmethodservice.InputMethodService
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import com.preonboarding.customkeyboard.databinding.ViewKeyboardBinding
+
+class KeyboardService : InputMethodService() {
+    private lateinit var binding: ViewKeyboardBinding
+
+    override fun onCreate() {
+        super.onCreate()
+        binding = ViewKeyboardBinding.inflate(layoutInflater)
+    }
+
+    private val keyboardReplacer = object : KeyboardActionListener {
+        override fun changeMode(mode: Mode) {
+            currentInputConnection?.finishComposingText()
+            when (mode) {
+                Mode.KOREA -> {
+                    binding.flKeyboard.removeAllViews()
+                }
+                Mode.ENGLISH -> {
+                    binding.flKeyboard.removeAllViews()
+                }
+                Mode.SYMBOL -> {
+                    binding.flKeyboard.removeAllViews()
+                }
+            }
+        }
+    }
+
+    override fun onCreateInputView(): View {
+        return binding.viewKeyboard
+    }
+
+
+    override fun updateInputViewShown() {
+        super.updateInputViewShown()
+        currentInputConnection.finishComposingText()
+        if (currentInputEditorInfo.inputType == EditorInfo.TYPE_CLASS_NUMBER) {
+            binding.flKeyboard.apply {
+                removeAllViews()
+                // TODO 숫자 패드
+            }
+        } else {
+            keyboardReplacer.changeMode(Mode.ENGLISH)
+        }
+    }
+}

--- a/app/src/main/java/com/preonboarding/customkeyboard/KeyboardService.kt
+++ b/app/src/main/java/com/preonboarding/customkeyboard/KeyboardService.kt
@@ -4,10 +4,11 @@ import android.inputmethodservice.InputMethodService
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import com.preonboarding.customkeyboard.databinding.ViewKeyboardBinding
+import com.preonboarding.customkeyboard.keyboard.KoreanKeyBoard
 
 class KeyboardService : InputMethodService() {
     private lateinit var binding: ViewKeyboardBinding
-
+    private lateinit var koreaKeyboard: KoreanKeyBoard
     override fun onCreate() {
         super.onCreate()
         binding = ViewKeyboardBinding.inflate(layoutInflater)
@@ -22,6 +23,8 @@ class KeyboardService : InputMethodService() {
                 }
                 Mode.ENGLISH -> {
                     binding.flKeyboard.removeAllViews()
+                    koreaKeyboard.inputConnection = currentInputConnection
+                    binding.flKeyboard.addView(koreaKeyboard.getLayout())
                 }
                 Mode.SYMBOL -> {
                     binding.flKeyboard.removeAllViews()
@@ -31,6 +34,10 @@ class KeyboardService : InputMethodService() {
     }
 
     override fun onCreateInputView(): View {
+        koreaKeyboard = KoreanKeyBoard(applicationContext, layoutInflater, keyboardReplacer).apply {
+            inputConnection = currentInputConnection
+            init()
+        }
         return binding.viewKeyboard
     }
 
@@ -41,7 +48,6 @@ class KeyboardService : InputMethodService() {
         if (currentInputEditorInfo.inputType == EditorInfo.TYPE_CLASS_NUMBER) {
             binding.flKeyboard.apply {
                 removeAllViews()
-                // TODO 숫자 패드
             }
         } else {
             keyboardReplacer.changeMode(Mode.ENGLISH)

--- a/app/src/main/java/com/preonboarding/customkeyboard/KeyboardService.kt
+++ b/app/src/main/java/com/preonboarding/customkeyboard/KeyboardService.kt
@@ -20,11 +20,11 @@ class KeyboardService : InputMethodService() {
             when (mode) {
                 Mode.KOREA -> {
                     binding.flKeyboard.removeAllViews()
+                    koreaKeyboard.inputConnection = currentInputConnection
+                    binding.flKeyboard.addView(koreaKeyboard.getLayout())
                 }
                 Mode.ENGLISH -> {
                     binding.flKeyboard.removeAllViews()
-                    koreaKeyboard.inputConnection = currentInputConnection
-                    binding.flKeyboard.addView(koreaKeyboard.getLayout())
                 }
                 Mode.SYMBOL -> {
                     binding.flKeyboard.removeAllViews()
@@ -50,7 +50,7 @@ class KeyboardService : InputMethodService() {
                 removeAllViews()
             }
         } else {
-            keyboardReplacer.changeMode(Mode.ENGLISH)
+            keyboardReplacer.changeMode(Mode.KOREA)
         }
     }
 }

--- a/app/src/main/java/com/preonboarding/customkeyboard/Mode.kt
+++ b/app/src/main/java/com/preonboarding/customkeyboard/Mode.kt
@@ -1,0 +1,5 @@
+package com.preonboarding.customkeyboard
+
+enum class Mode {
+    KOREA, ENGLISH, SYMBOL
+}

--- a/app/src/main/java/com/preonboarding/customkeyboard/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/preonboarding/customkeyboard/keyboard/Keyboard.kt
@@ -1,0 +1,45 @@
+package com.preonboarding.customkeyboard.keyboard
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.inputmethod.InputConnection
+import android.widget.LinearLayout
+import com.preonboarding.customkeyboard.KeyboardActionListener
+import com.preonboarding.customkeyboard.databinding.ViewKeyboardActionBinding
+
+abstract class Keyboard(
+    context: Context,
+    layoutInflater: LayoutInflater,
+    listener: KeyboardActionListener
+) {
+
+    private val height = 150
+    protected val config = context.resources.configuration
+
+    protected val binding = ViewKeyboardActionBinding.inflate(layoutInflater)
+    protected val keyboardActionListener = listener
+    var inputConnection: InputConnection? = null
+
+    protected fun setLayoutParamsLandScape(layout: LinearLayout) {
+        layout.layoutParams = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            (height * 0.7).toInt()
+        )
+    }
+
+    protected fun setLayoutParams(layout: LinearLayout) {
+        layout.layoutParams = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            height
+        )
+    }
+
+    abstract fun init()
+    abstract fun changeMode()
+    abstract fun setLayoutComponents()
+    abstract fun doSpaceClick(): View.OnClickListener
+    abstract fun doEnterClick(): View.OnClickListener
+    abstract fun doShiftClick(): View.OnClickListener
+    abstract fun doDeleteClick(): View.OnClickListener
+}

--- a/app/src/main/java/com/preonboarding/customkeyboard/keyboard/KoreaCombiner.kt
+++ b/app/src/main/java/com/preonboarding/customkeyboard/keyboard/KoreaCombiner.kt
@@ -1,0 +1,400 @@
+package com.preonboarding.customkeyboard.keyboard
+
+import android.content.Context
+import android.view.inputmethod.InputConnection
+import com.preonboarding.customkeyboard.R
+
+class KoreaCombiner(
+    private val inputConnection: InputConnection?,
+    private val context: Context
+) {
+    private var chosung: Char = '\u0000'
+    private var jungsung: Char = '\u0000'
+    private var jongsung: Char = '\u0000'
+    private var jonFlag: Char = '\u0000'
+    private var doubleJonFlag: Char = '\u0000'
+    var junFlag: Char = '\u0000'
+
+    private val chos: List<Int> = listOf(
+        0x3131,
+        0x3132,
+        0x3134,
+        0x3137,
+        0x3138,
+        0x3139,
+        0x3141,
+        0x3142,
+        0x3143,
+        0x3145,
+        0x3146,
+        0x3147,
+        0x3148,
+        0x3149,
+        0x314a,
+        0x314b,
+        0x314c,
+        0x314d,
+        0x314e
+    )
+    private val juns: List<Int> =listOf(
+        0x314f,
+        0x3150,
+        0x3151,
+        0x3152,
+        0x3153,
+        0x3154,
+        0x3155,
+        0x3156,
+        0x3157,
+        0x3158,
+        0x3159,
+        0x315a,
+        0x315b,
+        0x315c,
+        0x315d,
+        0x315e,
+        0x315f,
+        0x3160,
+        0x3161,
+        0x3162,
+        0x3163
+    )
+    private val jons: List<Int> = listOf(
+        0x0000,
+        0x3131,
+        0x3132,
+        0x3133,
+        0x3134,
+        0x3135,
+        0x3136,
+        0x3137,
+        0x3139,
+        0x313a,
+        0x313b,
+        0x313c,
+        0x313d,
+        0x313e,
+        0x313f,
+        0x3140,
+        0x3141,
+        0x3142,
+        0x3144,
+        0x3145,
+        0x3146,
+        0x3147,
+        0x3148,
+        0x314a,
+        0x314b,
+        0x314c,
+        0x314d,
+        0x314e
+    )
+
+    /**
+     * 0: ""
+     * 1: 모음
+     * 2: 모음 + 자음
+     * 3: 모음 + 자음 + 모읍립력
+     */
+    private var state = 0
+
+    fun clear() {
+        chosung = '\u0000'
+        jungsung = '\u0000'
+        jongsung = '\u0000'
+        jonFlag = '\u0000'
+        doubleJonFlag = '\u0000'
+        junFlag = '\u0000'
+    }
+
+    fun delete() {
+        when (state) {
+            0 -> {
+                inputConnection?.deleteSurroundingText(1, 0)
+            }
+            1 -> {
+                chosung = '\u0000'
+                state = 0
+                inputConnection?.setComposingText("", 1)
+                inputConnection?.commitText("", 1)
+            }
+            2 -> {
+                if (junFlag != '\u0000') {
+                    jungsung = junFlag
+                    junFlag = '\u0000'
+                    state = 2
+                    inputConnection?.setComposingText(makeHangul().toString(), 1)
+                } else {
+                    jungsung = '\u0000'
+                    junFlag = '\u0000'
+                    state = 1
+                    inputConnection?.setComposingText(chosung.toString(), 1)
+                }
+            }
+            3 -> {
+                if (doubleJonFlag == '\u0000') {
+                    jongsung = '\u0000'
+                    state = 2
+                } else {
+                    jongsung = jonFlag
+                    jonFlag = '\u0000'
+                    doubleJonFlag = '\u0000'
+                    state = 3
+                }
+                inputConnection?.setComposingText(makeHangul().toString(), 1)
+            }
+        }
+    }
+
+    private fun makeHangul(): Char {
+        if (state == 0) {
+            return '\u0000'
+        }
+        if (state == 1) {
+            return chosung
+        }
+        val choIndex = chos.indexOf(chosung.code)
+        val junIndex = juns.indexOf(jungsung.code)
+        val jonIndex = jons.indexOf(jongsung.code)
+
+        val result = 0xAC00 + 28 * 21 * choIndex + 28 * junIndex + jonIndex
+        return result.toChar()
+    }
+
+    fun commitSpace() {
+        directlyCommit()
+        inputConnection?.commitText(" ", 1)
+    }
+
+    fun directlyCommit() {
+        if (state == 0) {
+            return
+        }
+        inputConnection?.commitText(makeHangul().toString(), 1)
+        state = 0
+        clear()
+    }
+
+    fun commit(c: Char) {
+        if (chos.indexOf(c.code) < 0 && juns.indexOf(c.code) < 0 && jons.indexOf(c.code) < 0) {
+            directlyCommit()
+            inputConnection?.commitText(c.toString(), 1)
+            return
+        }
+        when (state) {
+            0 -> {
+                if (juns.indexOf(c.code) >= 0) {
+                    inputConnection?.commitText(c.toString(), 1)
+                    clear()
+                } else {
+                    state = 1
+                    chosung = c
+                    inputConnection?.setComposingText(chosung.toString(), 1)
+                }
+            }
+            1 -> {
+                if (chos.indexOf(c.code) >= 0) {
+                    inputConnection?.commitText(chosung.toString(), 1)
+                    clear()
+                    chosung = c
+                    inputConnection?.setComposingText(chosung.toString(), 1)
+                } else {
+                    state = 2
+                    jungsung = c
+                    inputConnection?.setComposingText(makeHangul().toString(), 1)
+                }
+            }
+            2 -> {
+                if (juns.indexOf(c.code) >= 0) {
+                    if (isDoubleJunEnable(c)) {
+                        inputConnection?.setComposingText(makeHangul().toString(), 1)
+                    } else {
+                        inputConnection?.apply {
+                            commitText(makeHangul().toString(), 1)
+                            commitText(c.toString(), 1)
+                        }
+                        clear()
+                        state = 0
+                    }
+                } else if (jons.indexOf(c.code) >= 0) {
+                    jongsung = c
+                    inputConnection?.setComposingText(makeHangul().toString(), 1)
+                    state = 3
+                } else {
+                    directlyCommit()
+                    chosung = c
+                    state = 1
+                    inputConnection?.setComposingText(makeHangul().toString(), 1)
+                }
+            }
+            3 -> {
+                if (jons.indexOf(c.code) >= 0) {
+                    if (isDoubleJonEnable(c)) {
+                        inputConnection?.setComposingText(makeHangul().toString(), 1)
+                    } else {
+                        inputConnection?.commitText(makeHangul().toString(), 1)
+                        clear()
+                        state = 1
+                        chosung = c
+                        inputConnection?.setComposingText(chosung.toString(), 1)
+                    }
+
+                } else if (chos.indexOf(c.code) >= 0) {
+                    inputConnection?.commitText(makeHangul().toString(), 1)
+                    state = 1
+                    clear()
+                    chosung = c
+                    inputConnection?.setComposingText(chosung.toString(), 1)
+                } else {
+                    var temp: Char = '\u0000'
+                    if (doubleJonFlag == '\u0000') {
+                        temp = jongsung
+                        jongsung = '\u0000'
+                        inputConnection?.commitText(makeHangul().toString(), 1)
+                    } else {
+                        temp = doubleJonFlag
+                        jongsung = jonFlag
+                        inputConnection?.commitText(makeHangul().toString(), 1)
+                    }
+                    state = 2
+                    clear()
+                    chosung = temp
+                    jungsung = c
+                    inputConnection?.setComposingText(makeHangul().toString(), 1)
+                }
+            }
+        }
+    }
+
+    private fun isDoubleJonEnable(c: Char): Boolean {
+        when (jungsung) {
+            'ㅗ' -> {
+                if (c == 'ㅏ') {
+                    junFlag = jungsung
+                    jungsung = 'ㅘ'
+                    return true
+                }
+                if (c == 'ㅐ') {
+                    junFlag = jungsung
+                    jungsung = 'ㅙ'
+                    return true
+                }
+                if (c == 'ㅣ') {
+                    junFlag = jungsung
+                    jungsung = 'ㅚ'
+                    return true
+                }
+                return false
+            }
+            'ㅜ' -> {
+                if (c == 'ㅓ') {
+                    junFlag = jungsung
+                    jungsung = 'ㅝ'
+                    return true
+                }
+                if (c == 'ㅔ') {
+                    junFlag = jungsung
+                    jungsung = 'ㅞ'
+                    return true
+                }
+                if (c == 'ㅣ') {
+                    junFlag = jungsung
+                    jungsung = 'ㅟ'
+                    return true
+                }
+                return false
+            }
+            'ㅡ' -> {
+                if (c == 'ㅣ') {
+                    junFlag = jungsung
+                    jungsung = 'ㅢ'
+                    return true
+                }
+                return false
+            }
+            else -> {
+                return false
+            }
+        }
+    }
+
+    private fun isDoubleJunEnable(c: Char): Boolean {
+        jonFlag = jongsung
+        doubleJonFlag = c
+        when (jongsung) {
+            'ㄱ' -> {
+                if (c == 'ㅅ') {
+                    jongsung = 'ㄳ'
+                    return true
+                }
+                return false
+            }
+            'ㄴ' -> {
+                if (c == 'ㅈ') {
+                    jongsung = 'ㄵ'
+                    return true
+                }
+                if (c == 'ㅎ') {
+                    jongsung = 'ㄶ'
+                    return true
+                }
+                return false
+            }
+            'ㄹ' -> {
+                if (c == 'ㄱ') {
+                    jongsung = 'ㄺ'
+                    return true
+                }
+                if (c == 'ㅁ') {
+                    jongsung = 'ㄻ'
+                    return true
+                }
+                if (c == 'ㅂ') {
+                    jongsung = 'ㄼ'
+                    return true
+                }
+                if (c == 'ㅅ') {
+                    jongsung = 'ㄽ'
+                    return true
+                }
+                if (c == 'ㅌ') {
+                    jongsung = 'ㄾ'
+                    return true
+                }
+                if (c == 'ㅍ') {
+                    jongsung = 'ㄿ'
+                    return true
+                }
+                if (c == 'ㅎ') {
+                    jongsung = 'ㅀ'
+                    return true
+                }
+                return false
+            }
+            'ㅂ' -> {
+                if (c == 'ㅅ') {
+                    jongsung = 'ㅄ'
+                    return true
+                }
+                return false
+            }
+            else -> {
+                return false
+            }
+        }
+    }
+
+    fun isJungsungAvailable(): Boolean {
+        if (jungsung == 'ㅙ' || jungsung == 'ㅞ' || jungsung == 'ㅢ' || jungsung == 'ㅐ' || jungsung == 'ㅔ' || jungsung == 'ㅛ' || jungsung == 'ㅒ' || jungsung == 'ㅖ') {
+            return false
+        }
+        return true
+    }
+
+    fun isDoubleJunsung(): Boolean {
+        if (jungsung == 'ㅙ' || jungsung == 'ㅞ' || jungsung == 'ㅚ' || jungsung == 'ㅝ' || jungsung == 'ㅟ' || jungsung == 'ㅘ' || jungsung == 'ㅢ') {
+            return true
+        }
+        return false
+    }
+}

--- a/app/src/main/java/com/preonboarding/customkeyboard/keyboard/KoreanKeyboard.kt
+++ b/app/src/main/java/com/preonboarding/customkeyboard/keyboard/KoreanKeyboard.kt
@@ -1,0 +1,305 @@
+package com.preonboarding.customkeyboard.keyboard
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+import android.os.SystemClock
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.inputmethod.InputConnection
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.LinearLayout
+import androidx.core.view.children
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import com.preonboarding.customkeyboard.KeyboardActionListener
+import com.preonboarding.customkeyboard.Mode
+import com.preonboarding.customkeyboard.R
+
+class KoreanKeyBoard(
+    private val context: Context,
+    layoutInflater: LayoutInflater,
+    listener: KeyboardActionListener
+) : Keyboard(context, layoutInflater, listener) {
+
+    private var isShiftOn: Boolean = false
+    private val keysText = ArrayList<List<String>>()
+    private val lineList = ArrayList<LinearLayout>()
+    private val buttons = ArrayList<Button>()
+    private lateinit var combiner: KoreaCombiner
+
+    fun getLayout(): LinearLayout {
+        combiner = KoreaCombiner(inputConnection, context)
+        setLayoutComponents()
+        return binding.layoutKeyboard
+    }
+
+    override fun init() {
+        combiner = KoreaCombiner(inputConnection, context)
+        if (config.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            setLayoutParamsLandScape(binding.lineNumber)
+            setLayoutParamsLandScape(binding.lineFirst)
+            setLayoutParamsLandScape(binding.lineSecond)
+            setLayoutParamsLandScape(binding.lineThird)
+            setLayoutParamsLandScape(binding.lineLast)
+        } else {
+            setLayoutParams(binding.lineNumber)
+            setLayoutParams(binding.lineFirst)
+            setLayoutParams(binding.lineSecond)
+            setLayoutParams(binding.lineThird)
+            setLayoutParams(binding.lineLast)
+        }
+
+        keysText.apply {
+            clear()
+            add(context.resources.getStringArray(R.array.number).toList())
+            add(context.resources.getStringArray(R.array.first_line_korea).toList())
+            add(context.resources.getStringArray(R.array.second_line_korea).toList())
+            add(context.resources.getStringArray(R.array.third_line_korea).toList())
+            add(context.resources.getStringArray(R.array.last_line).toList())
+        }
+        lineList.apply {
+            clear()
+            add(binding.lineNumber)
+            add(binding.lineFirst)
+            add(binding.lineSecond)
+            add(binding.lineThird)
+            add(binding.lineLast)
+        }
+
+    }
+
+    override fun changeMode() {
+        if (isShiftOn) {
+            isShiftOn = false
+            binding.btnKeyShift.ivSpecialKey.setImageResource(R.drawable.ic_shift_off)
+            for (button in buttons) {
+                when (button.text.toString()) {
+                    "ㅃ" -> {
+                        button.text = "ㅂ"
+                    }
+                    "ㅉ" -> {
+                        button.text = "ㅈ"
+                    }
+                    "ㄸ" -> {
+                        button.text = "ㄷ"
+                    }
+                    "ㄲ" -> {
+                        button.text = "ㄱ"
+                    }
+                    "ㅆ" -> {
+                        button.text = "ㅅ"
+                    }
+                    "ㅒ" -> {
+                        button.text = "ㅐ"
+                    }
+                    "ㅖ" -> {
+                        button.text = "ㅔ"
+                    }
+                }
+            }
+        } else {
+            isShiftOn = true
+            binding.btnKeyShift.ivSpecialKey.setImageResource(R.drawable.ic_shift_on)
+            for (button in buttons) {
+                when (button.text.toString()) {
+                    "ㅂ" -> {
+                        button.text = "ㅃ"
+                    }
+                    "ㅈ" -> {
+                        button.text = "ㅉ"
+                    }
+                    "ㄷ" -> {
+                        button.text = "ㄸ"
+                    }
+                    "ㄱ" -> {
+                        button.text = "ㄲ"
+                    }
+                    "ㅅ" -> {
+                        button.text = "ㅆ"
+                    }
+                    "ㅐ" -> {
+                        button.text = "ㅒ"
+                    }
+                    "ㅔ" -> {
+                        button.text = "ㅖ"
+                    }
+                }
+            }
+        }
+    }
+
+    override fun setLayoutComponents() {
+        for (i in lineList.indices) {
+            val childrenButton = lineList[i].children.toList()
+            val key = keysText[i]
+            for (item in childrenButton.indices) {
+                val button = childrenButton[item].findViewById<Button>(R.id.btn_key)
+                val specialKey = childrenButton[item].findViewById<ImageView>(R.id.iv_special_key)
+                var onClickListener: View.OnClickListener? = null
+                when (key[item]) {
+                    "Shift" -> {
+                        setSpecialKey(specialKey, R.drawable.ic_shift_off, doShiftClick())
+                        button.isEnabled = true
+                        onClickListener = doShiftClick()
+                    }
+                    "DEL" -> {
+                        setSpecialKey(specialKey, R.drawable.ic_backspace, doDeleteClick())
+                        button.isEnabled = true
+                        onClickListener = doDeleteClick()
+                    }
+                    "Space" -> {
+                        setSpecialKey(specialKey, R.drawable.ic_space_bar, doSpaceClick())
+                        button.isEnabled = true
+                        onClickListener = doSpaceClick()
+                    }
+                    "Enter" -> {
+                        setSpecialKey(specialKey, R.drawable.ic_enter, doEnterClick())
+                        button.isEnabled = true
+                        onClickListener = doEnterClick()
+                    }
+                    "Shortcut" -> {
+                        //TODO 선택된 단축기로 텍스트 표기
+                        button.setOnClickListener(doShortcutClick())
+                        onClickListener = doShortcutClick()
+                    }
+                    "!#1" -> {
+                        button.apply {
+                            text = key[item]
+                            setOnClickListener {
+                                keyboardActionListener.changeMode(Mode.SYMBOL)
+                            }
+                            buttons.add(this)
+                        }
+                        onClickListener = object : View.OnClickListener {
+                            override fun onClick(p0: View?) {
+                                keyboardActionListener.changeMode(Mode.SYMBOL)
+                            }
+                        }
+
+                    }
+                    "한/영" -> {
+                        button.apply {
+                            text = key[item]
+                            setOnClickListener {
+                                keyboardActionListener.changeMode(Mode.ENGLISH)
+                            }
+                            buttons.add(this)
+                        }
+                        onClickListener = object : View.OnClickListener {
+                            override fun onClick(p0: View?) {
+                                keyboardActionListener.changeMode(Mode.ENGLISH)
+                            }
+                        }
+                    }
+                    else -> {
+                        button.apply {
+                            text = key[item]
+                            buttons.add(this)
+                            setOnClickListener(getOnClickListener(this))
+                            onClickListener = getOnClickListener(this)
+                        }
+                    }
+                }
+                childrenButton[item].setOnClickListener(onClickListener)
+            }
+        }
+    }
+
+    private fun doShortcutClick(): View.OnClickListener {
+        return View.OnClickListener {
+            //TODO 단축기 세팅
+        }
+    }
+
+    override fun doSpaceClick(): View.OnClickListener {
+        return View.OnClickListener {
+            combiner.commitSpace()
+        }
+    }
+
+    override fun doEnterClick(): View.OnClickListener {
+        return View.OnClickListener {
+            combiner.directlyCommit()
+            sendKeyEvent()
+        }
+    }
+
+    override fun doShiftClick(): View.OnClickListener {
+        return View.OnClickListener {
+            changeMode()
+        }
+    }
+
+    override fun doDeleteClick(): View.OnClickListener {
+        return View.OnClickListener {
+            val cursor = inputConnection?.getSelectedText(InputConnection.GET_TEXT_WITH_STYLES)
+            cursor?.let {
+                if (cursor.length >= 2) {
+                    sendKeyEvent()
+                    combiner.clear()
+                } else {
+                    combiner.delete()
+                }
+            }
+        }
+    }
+
+    private fun getOnClickListener(button: Button): View.OnClickListener {
+        return View.OnClickListener {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                inputConnection?.requestCursorUpdates(InputConnection.CURSOR_UPDATE_IMMEDIATE)
+            }
+            val cursor = inputConnection?.getSelectedText(InputConnection.GET_TEXT_WITH_STYLES)
+            cursor?.let {
+                if (cursor.length >= 2) {
+                    sendKeyEvent()
+                    combiner.clear()
+                }
+            }
+            runCatching {
+                val tmpText = Integer.parseInt(button.text.toString())
+                combiner.directlyCommit()
+                inputConnection?.commitText(button.text.toString(), 1)
+            }.onFailure {
+                combiner.commit(button.text.toString().toCharArray().get(0))
+            }
+            if (isShiftOn) {
+                changeMode()
+            }
+        }
+    }
+
+    private fun sendKeyEvent() {
+        val eventTime = SystemClock.uptimeMillis()
+        inputConnection?.apply {
+            finishComposingText()
+            sendKeyEvent(
+                KeyEvent(
+                    eventTime, eventTime,
+                    KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL, 0, 0, 0, 0,
+                    KeyEvent.FLAG_SOFT_KEYBOARD
+                )
+            )
+            sendKeyEvent(
+                KeyEvent(
+                    SystemClock.uptimeMillis(), eventTime,
+                    KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DEL, 0, 0, 0, 0,
+                    KeyEvent.FLAG_SOFT_KEYBOARD
+                )
+            )
+        }
+    }
+
+/*    private */
+
+    private fun setSpecialKey(imageView: ImageView, drawable: Int, listener: View.OnClickListener) {
+        imageView.apply {
+            setImageResource(drawable)
+            isVisible = true
+            setOnClickListener(listener)
+        }
+    }
+}

--- a/app/src/main/java/com/preonboarding/customkeyboard/keyboard/KoreanKeyboard.kt
+++ b/app/src/main/java/com/preonboarding/customkeyboard/keyboard/KoreanKeyboard.kt
@@ -12,7 +12,6 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.core.view.children
-import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.preonboarding.customkeyboard.KeyboardActionListener
 import com.preonboarding.customkeyboard.Mode
@@ -238,6 +237,7 @@ class KoreanKeyBoard(
             val cursor = inputConnection?.getSelectedText(InputConnection.GET_TEXT_WITH_STYLES)
             cursor?.let {
                 if (cursor.length >= 2) {
+                    inputConnection?.finishComposingText()
                     sendKeyEvent()
                     combiner.clear()
                 } else {
@@ -255,6 +255,7 @@ class KoreanKeyBoard(
             val cursor = inputConnection?.getSelectedText(InputConnection.GET_TEXT_WITH_STYLES)
             cursor?.let {
                 if (cursor.length >= 2) {
+                    inputConnection?.finishComposingText()
                     sendKeyEvent()
                     combiner.clear()
                 }
@@ -275,7 +276,6 @@ class KoreanKeyBoard(
     private fun sendKeyEvent() {
         val eventTime = SystemClock.uptimeMillis()
         inputConnection?.apply {
-            finishComposingText()
             sendKeyEvent(
                 KeyEvent(
                     eventTime, eventTime,
@@ -292,8 +292,6 @@ class KoreanKeyBoard(
             )
         }
     }
-
-/*    private */
 
     private fun setSpecialKey(imageView: ImageView, drawable: Int, listener: View.OnClickListener) {
         imageView.apply {

--- a/app/src/main/java/com/preonboarding/customkeyboard/keyboard/KoreanKeyboard.kt
+++ b/app/src/main/java/com/preonboarding/customkeyboard/keyboard/KoreanKeyboard.kt
@@ -14,7 +14,6 @@ import android.widget.LinearLayout
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import com.preonboarding.customkeyboard.KeyboardActionListener
-import com.preonboarding.customkeyboard.Mode
 import com.preonboarding.customkeyboard.R
 
 class KoreanKeyBoard(
@@ -38,17 +37,17 @@ class KoreanKeyBoard(
     override fun init() {
         combiner = KoreaCombiner(inputConnection, context)
         if (config.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            setLayoutParamsLandScape(binding.lineNumber)
+            /* setLayoutParamsLandScape(binding.lineNumber)*/
             setLayoutParamsLandScape(binding.lineFirst)
             setLayoutParamsLandScape(binding.lineSecond)
             setLayoutParamsLandScape(binding.lineThird)
-            setLayoutParamsLandScape(binding.lineLast)
+            /* setLayoutParamsLandScape(binding.lineLast)*/
         } else {
-            setLayoutParams(binding.lineNumber)
+            /*setLayoutParams(binding.lineNumber)*/
             setLayoutParams(binding.lineFirst)
             setLayoutParams(binding.lineSecond)
             setLayoutParams(binding.lineThird)
-            setLayoutParams(binding.lineLast)
+            /*setLayoutParams(binding.lineLast)*/
         }
 
         keysText.apply {
@@ -165,7 +164,8 @@ class KoreanKeyBoard(
                         onClickListener = doShortcutClick()
                     }
                     "!#1" -> {
-                        button.apply {
+                        button.text = key[item]
+                        /*button.apply {
                             text = key[item]
                             setOnClickListener {
                                 keyboardActionListener.changeMode(Mode.SYMBOL)
@@ -176,11 +176,12 @@ class KoreanKeyBoard(
                             override fun onClick(p0: View?) {
                                 keyboardActionListener.changeMode(Mode.SYMBOL)
                             }
-                        }
+                        }*/
 
                     }
                     "한/영" -> {
-                        button.apply {
+                        button.text = key[item]
+                        /*button.apply {
                             text = key[item]
                             setOnClickListener {
                                 keyboardActionListener.changeMode(Mode.ENGLISH)
@@ -191,7 +192,7 @@ class KoreanKeyBoard(
                             override fun onClick(p0: View?) {
                                 keyboardActionListener.changeMode(Mode.ENGLISH)
                             }
-                        }
+                        }*/
                     }
                     else -> {
                         button.apply {

--- a/app/src/main/res/drawable/ic_backspace.xml
+++ b/app/src/main/res/drawable/ic_backspace.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="@color/white" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/white" android:pathData="M21,11H6.83l3.58,-3.59L9,6l-6,6 6,6 1.41,-1.41L6.83,13H21z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_enter.xml
+++ b/app/src/main/res/drawable/ic_enter.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="@color/white" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,7v4H5.83l3.58,-3.59L8,6l-6,6 6,6 1.41,-1.41L5.83,13H21V7z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_shift_off.xml
+++ b/app/src/main/res/drawable/ic_shift_off.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/white"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8 -8,8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_shift_on.xml
+++ b/app/src/main/res/drawable/ic_shift_on.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8 -8,8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_space_bar.xml
+++ b/app/src/main/res/drawable/ic_space_bar.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/white"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,9v4H6V9H4v6h16V9z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,13 +6,17 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
+    <EditText
+        android:id="@+id/editTextTextPersonName"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginStart="101dp"
+        android:layout_marginTop="218dp"
+        android:layout_marginEnd="101dp"
+        android:ems="10"
+        android:inputType="textPersonName"
+        android:text="Name"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_keyboard.xml
+++ b/app/src/main/res/layout/item_keyboard.xml
@@ -3,7 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:paddingHorizontal="4dp"
+    android:paddingVertical="3dp">
 
     <TextView
         android:id="@+id/tv_second_text"
@@ -18,7 +20,10 @@
         android:id="@+id/btn_key"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:duplicateParentState="true" />
+        android:background="#3F3D3D"
+        android:duplicateParentState="true"
+        android:gravity="center"
+        android:textColor="@color/white" />
 
     <ImageView
         android:id="@+id/iv_special_key"

--- a/app/src/main/res/layout/item_keyboard.xml
+++ b/app/src/main/res/layout/item_keyboard.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tv_second_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="ㅃ" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_key"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:duplicateParentState="true" />
+
+    <ImageView
+        android:id="@+id/iv_special_key"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="3dp"
+        android:contentDescription="@null"
+        android:duplicateParentState="true"
+        android:scaleType="centerInside"
+        android:visibility="gone" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_keyboard.xml
+++ b/app/src/main/res/layout/view_keyboard.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/view_keyboard"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/fl_keyboard"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    </FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_keyboard_action.xml
+++ b/app/src/main/res/layout/view_keyboard_action.xml
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/layout_keyboard"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#1B1B1B"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/line_number"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:layout_weight="1"
+        android:baselineAligned="false"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/btn_key_1"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_2"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_3"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_4"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_5"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_6"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_7"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_8"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"></include>
+
+        <include
+            android:id="@+id/btn_key_9"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"></include>
+
+        <include
+            android:id="@+id/btn_key_0"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"></include>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/line_first"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:layout_weight="1"
+        android:baselineAligned="false"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/btn_key_q"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_w"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_e"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_r"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_t"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_y"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_u"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_i"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_o"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+        </include>
+
+        <include
+            android:id="@+id/btn_key_p"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/line_second"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:layout_weight="1"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
+        android:paddingLeft="12dp"
+        android:paddingRight="12dp">
+
+        <include
+            android:id="@+id/btn_key_a"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_s"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_d"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_f"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_g"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_h"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_j"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_k"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_l"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/line_third"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:layout_weight="1"
+        android:baselineAligned="false"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/btn_key_shift"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1.5" />
+
+        <include
+            android:id="@+id/btn_key_z"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_x"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_c"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_v"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_b"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_n"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_m"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_del"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1.7" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/line_last"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:layout_weight="1"
+        android:baselineAligned="false"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/btn_key_symbols"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2" />
+
+        <include
+            android:id="@+id/btn_key_mode_change"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_shortcut"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_space"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="4" />
+
+        <include
+            android:id="@+id/btn_key_dot"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <include
+            android:id="@+id/btn_key_enter"
+            layout="@layout/item_keyboard"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,57 @@
 <resources>
     <string name="app_name">android-wanted-CustomKeyboardApp</string>
+    <string-array name="number">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>0</item>
+    </string-array>
+    <string-array name="first_line_korea">
+        <item>ㅂ</item>
+        <item>ㅈ</item>
+        <item>ㄷ</item>
+        <item>ㄱ</item>
+        <item>ㅅ</item>
+        <item>ㅛ</item>
+        <item>ㅕ</item>
+        <item>ㅑ</item>
+        <item>ㅐ</item>
+        <item>ㅔ</item>
+    </string-array>
+    <string-array name="second_line_korea">
+        <item>ㅁ</item>
+        <item>ㄴ</item>
+        <item>ㅇ</item>
+        <item>ㄹ</item>
+        <item>ㅎ</item>
+        <item>ㅗ</item>
+        <item>ㅓ</item>
+        <item>ㅏ</item>
+        <item>ㅣ</item>
+    </string-array>
+    <string-array name="third_line_korea">
+        <item>Shift</item>
+        <item>ㅋ</item>
+        <item>ㅌ</item>
+        <item>ㅊ</item>
+        <item>ㅍ</item>
+        <item>ㅠ</item>
+        <item>ㅜ</item>
+        <item>ㅡ</item>
+        <item>DEL</item>
+    </string-array>
+    <string-array name="last_line">
+        <item>!#1</item>
+        <item>한/영</item>
+        <item>Shortcut</item>
+        <item>Space</item>
+        <item>.</item>
+        <item>Enter</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/custom_keyboard.xml
+++ b/app/src/main/res/xml/custom_keyboard.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<input-method xmlns:android="http://schemas.android.com/apk/res/android">
+    <subtype
+        android:imeSubtypeMode="keyboard"
+        android:label="WantedKeyboard" />
+</input-method>


### PR DESCRIPTION
## 구현
-  한글 키보드 구현
-  한글 조합 구현(버그)

## 캡처
![image](https://user-images.githubusercontent.com/86879099/195668692-e2c8b0d3-a456-4622-936e-2fd8ce700638.png)
- 동그라미 친 부분이 단축키 부분입니다.
- KoreanKeyboard.kt 에 "Shortcut" -> {} 블록에 구현해야합니다..

## 버그
- 엔터를 누르면 지워지고,, 지우기를 누르면 안지워지네요 ㅠㅠ
- 이중 모음이 안됩니다 ㅠㅠ
- 마찬가지로 자음+모음 조합일 때 지우면 모음만 지워져야 하는데 바로 지워집니다..

## etc
- 버그가 많아서 draft 모드로 우선 올립니다.. 세번째 부분을 받아서 작업하셔야 할 것 같아서 위 브랜치코드 받아서 하시면 될 것 같습니다 ㅠㅠ 죄송합니다
- 급한대로 하드코딩이 난무합니다.

